### PR TITLE
feat: add universal-commerce-analytics submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "data-agent-kit-starter-pack"]
 	path = data-agent-kit-starter-pack
 	url = https://github.com/gemini-cli-extensions/data-agent-kit-starter-pack
+[submodule "universal-commerce-analytics"]
+	path = universal-commerce-analytics
+	url = https://github.com/haiyuan-eng-google/Universal-Commerce-Protocol-Analytics.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,6 @@
 [submodule "data-agent-kit-starter-pack"]
 	path = data-agent-kit-starter-pack
 	url = https://github.com/gemini-cli-extensions/data-agent-kit-starter-pack
-[submodule "universal-commerce-analytics"]
-	path = universal-commerce-analytics
+[submodule "universal-commerce-protocol-analytics"]
+	path = universal-commerce-protocol-analytics
 	url = https://github.com/haiyuan-eng-google/Universal-Commerce-Protocol-Analytics.git


### PR DESCRIPTION
This PR adds the [Universal-Commerce-Protocol-Analytics](https://github.com/haiyuan-eng-google/Universal-Commerce-Protocol-Analytics) repository as a submodule under the path 'universal-commerce-analytics'.