### PR TITLE
feat: Add Google Cloud Storage Repo as a Submodule

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -96,6 +96,19 @@
       "category": "Databases"
     },
     {
+      "name": "google-cloud-storage",
+      "source": {
+        "source": "local",
+        "path": "./google-cloud-storage"
+      },
+      "description": "Vetted Google Cloud Storage skills for your coding agent.",
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Storage"
+    },
+    {
       "name": "looker",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -74,6 +74,14 @@
       "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem."
     },
     {
+      "name": "google-cloud-storage",
+      "source": {
+        "source": "github",
+        "repo": "gemini-cli-extensions/google-cloud-storage"
+      },
+      "description": "Vetted Google Cloud Storage skills for your coding agent."
+    },
+    {
       "name": "looker",
       "source": {
         "source": "github",

--- a/.gitmodules
+++ b/.gitmodules
@@ -38,3 +38,7 @@
 	path = data-agent-kit-starter-pack
 	url = https://github.com/gemini-cli-extensions/data-agent-kit-starter-pack
 	branch = 0.4.0
+[submodule "google-cloud-storage"]
+	path = google-cloud-storage
+	url = https://github.com/gemini-cli-extensions/google-cloud-storage
+	branch = 1.1.0

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ These extensions package product-specific Skills and MCP servers for use in any 
 | **Cloud SQL for PostgreSQL** | https://github.com/gemini-cli-extensions/cloud-sql-postgresql | Create, connect, and interact with a Cloud SQL for PostgreSQL database and data. |
 | **Cloud SQL for SQL Server** | https://github.com/gemini-cli-extensions/cloud-sql-sqlserver | Connect to Cloud SQL for SQL Server. |
 | **Firestore** | https://github.com/gemini-cli-extensions/firestore-native | Connect and interact with Cloud Firestore. |
+| **Google Cloud Storage** | https://github.com/gemini-cli-extensions/google-cloud-storage | Vetted Google Cloud Storage skills for your coding agent. |
 | **Looker** | https://github.com/gemini-cli-extensions/looker | Connect to Looker. |
 | **Oracle Database** | https://github.com/gemini-cli-extensions/oracledb | Connect, query, and interact with Oracle Databases and their data within Gemini CLI. |
 | **Spanner** | https://github.com/gemini-cli-extensions/spanner | Connect and interact with Spanner data using natural language. |


### PR DESCRIPTION
## What
Adds the [Google Cloud Storage](https://github.com/gemini-cli-extensions/google-cloud-storage) extension to the kit as a git submodule pinned to release `1.1.0`, and registers it in the marketplace manifests and the README so it's discoverable and installable for Claude Code and Codex users.

## Changes

  - **`.gitmodules`** — new `google-cloud-storage` submodule → `gemini-cli-extensions/google-cloud-storage`, `branch =
  1.1.0` (`be1ea65`).
  - **`google-cloud-storage`** — submodule pinned to `1.1.0`.
  - **`README.md`** — row in the Extensions & Plugins table.
  - **`.claude-plugin/marketplace.json`** — registry entry (github source).
  - **`.agents/plugins/marketplace.json`** — registry entry (local source, `category: "Storage"`).
  
