### PR TITLE
fix: switch Codex plugins to url source and update Codex install docs

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,9 +7,8 @@
     {
       "name": "alloydb",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/alloydb.git",
-        "path": "./",
         "ref": "0.2.0"
       },
       "description": "Create, connect, and interact with an AlloyDB for PostgreSQL database and data.",
@@ -22,9 +21,8 @@
     {
       "name": "alloydb-omni",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/alloydb-omni.git",
-        "path": "./",
         "ref": "0.2.1"
       },
       "description": "Create, connect, and interact with an AlloyDB Omni database and data.",
@@ -37,9 +35,8 @@
     {
       "name": "bigtable",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/GoogleCloudPlatform/cloud-bigtable-ecosystem.git",
-        "path": "./",
         "ref": "v0.4.0"
       },
       "description": "Connect, query, and interact with Cloud Bigtable.",
@@ -52,9 +49,8 @@
     {
       "name": "cloud-sql-mysql",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/cloud-sql-mysql.git",
-        "path": "./",
         "ref": "0.2.0"
       },
       "description": "Connect and interact with a Cloud SQL for MySQL database and data.",
@@ -67,9 +63,8 @@
     {
       "name": "cloud-sql-postgresql",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/cloud-sql-postgresql.git",
-        "path": "./",
         "ref": "0.4.0"
       },
       "description": "Create, connect, and interact with a Cloud SQL for PostgreSQL database and data.",
@@ -82,9 +77,8 @@
     {
       "name": "cloud-sql-sqlserver",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/cloud-sql-sqlserver.git",
-        "path": "./",
         "ref": "0.2.0"
       },
       "description": "Connect to Cloud SQL for SQL Server.",
@@ -97,9 +91,8 @@
     {
       "name": "firestore-native",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/firestore-native.git",
-        "path": "./",
         "ref": "0.3.0"
       },
       "description": "Connect and interact with Cloud Firestore.",
@@ -112,9 +105,8 @@
     {
       "name": "data-agent-kit-starter-pack",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/data-agent-kit-starter-pack.git",
-        "path": "./",
         "ref": "0.2.0"
       },
       "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
@@ -127,9 +119,8 @@
     {
       "name": "looker",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/looker.git",
-        "path": "./",
         "ref": "0.3.4"
       },
       "description": "Connect to Looker.",
@@ -142,9 +133,8 @@
     {
       "name": "oracledb",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/oracledb.git",
-        "path": "./",
         "ref": "0.2.1"
       },
       "description": "Connect, query, and interact with Oracle Databases and their data within Gemini CLI.",
@@ -157,9 +147,8 @@
     {
       "name": "spanner",
       "source": {
-        "source": "git-subdir",
+        "source": "url",
         "url": "https://github.com/gemini-cli-extensions/spanner.git",
-        "path": "./",
         "ref": "0.3.1"
       },
       "description": "Connect and interact with Spanner data using natural language.",

--- a/README.md
+++ b/README.md
@@ -60,18 +60,14 @@ claude plugin marketplace update data-agent-kit
 Codex utilizes a marketplace system for plugins. Install the Data Agent Kit marketplace to access all Data Cloud plugins:
 
 ```bash
-# Step 1. Clone the repo
-git clone --branch 0.1.0 https://github.com/GoogleCloudPlatform/data-agent-kit.git
-cd data-agent-kit
+# Step 1. Install marketplace
+codex plugin marketplace add GoogleCloudPlatform/data-agent-kit
 
-# Step 2. Open the plugin manager interface
-codex
-# Browse & install plugins from available marketplaces.
-/plugins
+# Step 2. Install a plugin
+codex plugin install <plugin-name>@data-agent-kit
 
 # Optional. Update the marketplace
-git fetch --tags
-git checkout 0.1.0
+codex plugin marketplace upgrade data-agent-kit
 ```
 
 </details>

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,37 @@
         "github-actions"
       ],
       "pinDigests": true
+    },
+    {
+      "matchManagers": [
+        "git-submodules",
+        "custom.jsonata"
+      ],
+      "groupName": "{{depName}}"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": [
+        "/^\\.claude-plugin/marketplace\\.json$/"
+      ],
+      "matchStrings": [
+        "plugins.{ \"depName\": $substringAfter(source.repo, \"/\"), \"packageName\": source.repo, \"currentValue\": source.ref }"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": [
+        "/^\\.agents/plugins/marketplace\\.json$/"
+      ],
+      "matchStrings": [
+        "plugins.($r := $replace(source.url, /^https:\\/\\/github\\.com\\/|\\.git$/, \"\"); { \"depName\": $substringAfter($r, \"/\"), \"packageName\": $r, \"currentValue\": source.ref })"
+      ],
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
- Switch all plugin entries in Codex marketplace.json from `git-subdir` to `url`source type (drops the path: "./" field).
- Update Codex install instructions in README.md to use the native codex plugin marketplace add/install/upgrade commands instead of the prior git clone + /plugins UI flow.
- Update renovate configuration for pin plugin version in marketplace files

Local Codex testing (pointing the the PR's source):
```
codex plugin marketplace list
codex plugin marketplace add helloeve/data-agent-kit@update-source
codex plugin add alloydb@data-agent-kit
```

Renovate validation:
```
npx --yes renovate --platform=local --dry-run=full
```