### PR TITLE
fix: tighten renovate to only trigger at tagged version

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -107,7 +107,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/gemini-cli-extensions/data-agent-kit-starter-pack.git",
-        "ref": "0.2.0"
+        "ref": "0.4.0"
       },
       "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem.",
       "policy": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
       "source": {
         "source": "github",
         "repo": "gemini-cli-extensions/data-agent-kit-starter-pack",
-        "ref": "0.2.0"
+        "ref": "0.4.0"
       },
       "description": "This plugin provides a specialized suite of skills for data engineers and database practitioners working on Google Cloud. It acts as an expert assistant, allowing you to use natural language prompts in your preferred coding agent to architect complex data pipelines, transform data with dbt, write Spark and BigQuery SQL notebooks, and orchestrate end-to-end workflows across GCP's data ecosystem."
     },

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,17 @@
         "git-submodules",
         "custom.jsonata"
       ],
-      "groupName": "{{depName}}"
+      "groupName": "{{depName}}",
+      "semanticCommitType": "feat"
+    },
+    {
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": false
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -52,7 +52,7 @@
       "matchStrings": [
         "plugins.{ \"depName\": $substringAfter(source.repo, \"/\"), \"packageName\": source.repo, \"currentValue\": source.ref }"
       ],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-tags"
     },
     {
       "customType": "jsonata",
@@ -63,7 +63,7 @@
       "matchStrings": [
         "plugins.($r := $replace(source.url, /^https:\\/\\/github\\.com\\/|\\.git$/, \"\"); { \"depName\": $substringAfter($r, \"/\"), \"packageName\": $r, \"currentValue\": source.ref })"
       ],
-      "datasourceTemplate": "github-releases"
+      "datasourceTemplate": "github-tags"
     }
   ]
 }


### PR DESCRIPTION
This PR introduces back the additional rules in renovate.json to tighten the triggering on tagged version

Tested locally with the following command and validated changes like https://github.com/GoogleCloudPlatform/data-agent-kit/pull/36 not appearing in the log.
 
```
RENOVATE_CONFIG_FILE="$(pwd)/renovate.json" \
LOG_LEVEL=debug npx --yes renovate --dry-run=full --autodiscover=false \
  GoogleCloudPlatform/data-agent-kit
```

BEGIN_COMMIT_OVERRIDE
ci: tighten renovate to only trigger at tagged version
END_COMMIT_OVERRIDE