### PR TITLE
docs: use singular `agy plugin install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Antigravity CLI installs plugins directly from remote GitHub repositories. You h
 Installs all Data Cloud plugins from this repository in one step:
 
 ```bash
-agy plugins install https://github.com/GoogleCloudPlatform/data-agent-kit
+agy plugin install https://github.com/GoogleCloudPlatform/data-agent-kit
 ```
 
 **Option 2. Install individual plugins from their product repositories**
@@ -90,14 +90,14 @@ agy plugins install https://github.com/GoogleCloudPlatform/data-agent-kit
 Point `agy` at a specific plugin's repository to install just that one:
 
 ```bash
-agy plugins install <REPO>
+agy plugin install <REPO>
 ```
 
 For example:
 
 ```bash
-agy plugins install https://github.com/gemini-cli-extensions/alloydb
-agy plugins install https://github.com/gemini-cli-extensions/spanner
+agy plugin install https://github.com/gemini-cli-extensions/alloydb
+agy plugin install https://github.com/gemini-cli-extensions/spanner
 ```
 
 See the [Individual Extensions & Plugins](#-individual-extensions--plugins) table below for the full list of repositories.


### PR DESCRIPTION
## Summary
- Correct the Antigravity CLI install command from `agy plugins install` to `agy plugin install` (singular) throughout the README