### PR TITLE
fix: merge two renovate PRs into one

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "git-submodules",
         "custom.jsonata"
       ],
-      "groupName": "{{depName}}",
+      "groupName": "{{{replace 'https://github.com/' '' sourceUrl}}}",
       "semanticCommitType": "feat"
     },
     {
@@ -67,4 +67,3 @@
     }
   ]
 }
-

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "git-submodules",
         "custom.jsonata"
       ],
-      "groupName": "{{{replace 'https://github.com/' '' sourceUrl}}}",
+      "groupName": "{{{replace 'plugins/' '' depName}}}",
       "semanticCommitType": "feat"
     },
     {


### PR DESCRIPTION
This PR introduce a replace rule to ensure single PR will be raised for an individual plugin.

The original `groupName: {{depName}}` split because git-submodules emits `depName: plugins/<plugin>` and `packageName: https://github.com/...` while the jsonata managers emit `depName: <plugin>` and `packageName: gemini-cli-extensions/looker` — neither field matched across all three.
